### PR TITLE
Update hcert-kotlin-jvm dependency to 1.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.journeyapps:zxing-android-embedded:4.1.0'
-    implementation 'ehn.techiop.hcert:hcert-kotlin-jvm:1.0.1-SNAPSHOT'
+    implementation 'ehn.techiop.hcert:hcert-kotlin-jvm:1.0.2-SNAPSHOT'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'


### PR DESCRIPTION
Update dependency to `ehn.techiop.hcert:hcert-kotlin-jvm` to version `1.0.2-SNAPSHOT` (current version, as defined here: https://github.com/ehn-dcc-development/hcert-kotlin/blob/main/build.gradle.kts#L10).

Otherwise build of the app will fail (if `hcert-kotlin` was published before to local repo with `./gradlew publishToMavenLocal`).